### PR TITLE
Control points initialize with default hit points and life regeneration

### DIFF
--- a/jass/Main/Game Logic/CPCapture.j
+++ b/jass/Main/Game Logic/CPCapture.j
@@ -1,11 +1,9 @@
 
 library CPCapture initializer OnInit requires AIDS
 
-  //**CONFIG
   globals
     private constant real CAPTURE_THRESHOLD = 0.8   //Percentage of maximum HP; below this, the CP will go to the damager
   endglobals
-  //*ENDCONFIG
 
   private function Actions takes nothing returns nothing
     local unit attacker = GetEventDamageSource()
@@ -17,9 +15,7 @@ library CPCapture initializer OnInit requires AIDS
       if hp < CAPTURE_THRESHOLD then
         call BlzSetEventDamage(0)
         call SetUnitOwner(attacked, GetOwningPlayer(attacker), true)
-        call BlzSetUnitMaxHP(attacked, 10000)
         call SetUnitLifePercentBJ(attacked, 85)
-        call UnitAddAbility(attacked, 'A0UT')
       endif  
     endif      
 

--- a/jass/Main/Libraries/MacroTools/ControlPoints.j
+++ b/jass/Main/Libraries/MacroTools/ControlPoints.j
@@ -5,6 +5,9 @@ library ControlPoint initializer OnInit requires AIDS
     ControlPoint array CPData
     Event OnControlPointLoss    
     Event OnControlPointOwnerChange   
+
+    private constant integer REGENERATION_ABILITY = 'A0UT' //An ability that increases hit point regeneration
+    private constant integer MAX_HITPOINTS = 10000 //All Control Points get given this many hitpoints
   endglobals
   
   struct ControlPoint
@@ -106,6 +109,10 @@ library ControlPoint initializer OnInit requires AIDS
       
       call GroupAddUnit(ControlPoints,u)
       call GroupAddUnit(person.cpGroup, u)
+
+      call BlzSetUnitMaxHP(u, MAX_HITPOINTS)
+      call UnitAddAbility(u, REGENERATION_ABILITY)
+      call SetUnitLifePercentBJ(u, 100)
 
       set OwningPerson.ControlPointValue = OwningPerson.ControlPointValue + this.value
       set OwningPerson.ControlPointCount = OwningPerson.ControlPointCount + 1


### PR DESCRIPTION
Control Points currently change their hit points and life regeneration when captured, which is apparently not intended behaviour. This makes it so those values are assigned as soon as the Control Point is initialized.